### PR TITLE
remove indirect object syntax from examples

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ SYNOPSIS
       use strict;
       use Continuity;
 
-      my $server = new Continuity;
+      my $server = Continuity->new;
       $server->loop;
 
       sub main {
@@ -50,7 +50,7 @@ GETTING STARTED
       use strict;
       use Continuity;
 
-      my $server = new Continuity;
+      my $server = Continuity->new;
       $server->loop;
 
       sub main {

--- a/eg/callback_counter.pl
+++ b/eg/callback_counter.pl
@@ -18,7 +18,7 @@ as a very simple tutorial of the basic functionality.
 
 use Continuity;
 use Continuity::RequestCallbacks;
-my $server = new Continuity;
+my $server = Continuity->new;
 $server->loop;
 
 # Main is invoked when we get a new session

--- a/eg/counter.pl
+++ b/eg/counter.pl
@@ -17,7 +17,7 @@ as a very simple tutorial of the basic functionality.
 =cut
 
 use Continuity;
-my $server = new Continuity;
+my $server = Continuity->new;
 $server->loop;
 
 # Ask a question and keep asking until they answer. General purpose prompt.

--- a/eg/fcgi_nocont.fcgi
+++ b/eg/fcgi_nocont.fcgi
@@ -7,9 +7,9 @@ use IO::Handle;
 
 my $count = 0;
 
-my $in = new IO::Handle;
-my $out = new IO::Handle;
-my $err = new IO::Handle;
+my $in = IO::Handle->new;
+my $out = IO::Handle->new;
+my $err = IO::Handle->new;
 my $r = FCGI::Request($in,$out,$err);
 
 while($r->Accept() >= 0) {

--- a/eg/guess-peek.pl
+++ b/eg/guess-peek.pl
@@ -6,7 +6,7 @@ use warnings;
 use Continuity;
 use Continuity::Inspector;
 
-my $server = new Continuity(
+my $server = Continuity->new(
       port => 8080,
       ip_session => 0,
       cookie_session => 'sid',

--- a/eg/guess.fcgi
+++ b/eg/guess.fcgi
@@ -6,7 +6,7 @@ use warnings;
 use Continuity;
 use Continuity::Adapt::FCGI;
 
-my $server = new Continuity(
+my $server = Continuity->new(
   adapter => 'FCGI',
 );
 $server->loop;

--- a/eg/hello.fcgi
+++ b/eg/hello.fcgi
@@ -5,7 +5,7 @@ use warnings;
 
 use Continuity;
 use Continuity::Adapt::FCGI;
-my $server = new Continuity(
+my $server = Continuity->new(
   adapter => 'FCGI',
 );
 

--- a/eg/hello.pl
+++ b/eg/hello.pl
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Continuity;
 
-my $server = new Continuity(
+my $server = Continuity->new(
   path_session => 1,
   port => 8080
 );

--- a/eg/leakfinder.pl
+++ b/eg/leakfinder.pl
@@ -8,7 +8,7 @@ use Devel::Size qw(size total_size);
 use Data::Dumper;
 
 use Continuity;
-my $server = new Continuity(
+my $server = Continuity->new(
   path_session => 1,
   port => 18081,
 );

--- a/eg/supercounter.pl
+++ b/eg/supercounter.pl
@@ -15,7 +15,7 @@ code. We even implement our own 'prompt'...
 =cut
 
 use Continuity;
-my $server = new Continuity(
+my $server = Continuity->new(
     port => 8080,
     query_session => 'sid',
 );
@@ -96,7 +96,7 @@ package Main;
 sub main {
   my $request = shift;
 
-  my @counter = map { new Counter } 1..5;
+  my @counter = map { Counter->new } 1..5;
 
   while(1) {
     foreach my $counter (@counter) {

--- a/eg/telnet-terminal.pl
+++ b/eg/telnet-terminal.pl
@@ -20,7 +20,7 @@ my $r = shift;
 
 my ($host, $port) = ('localhost', 23);
 
-my $t = new Net::Telnet (
+my $t = Net::Telnet->new(
   'Host' => $host,
   'Port' => $port,
   'Errmode' => 'return',
@@ -35,7 +35,7 @@ $t->option_accept ('Do' => TELOPT_TTYPE);
 $t->suboption_callback (\&subopt_callback);
 $t->timeout(undef);
 
-my $vt = Term::VT102->new (
+my $vt = Term::VT102->new(
   'cols' => 80,
   'rows' => 23,
 );

--- a/lib/Continuity.pm
+++ b/lib/Continuity.pm
@@ -13,7 +13,7 @@ Continuity - Abstract away statelessness of HTTP, for stateful Web applications
   use strict;
   use Continuity;
 
-  my $server = new Continuity;
+  my $server = Continuity->new;
   $server->loop;
 
   sub main {
@@ -57,7 +57,7 @@ Here's a simple example:
   use strict;
   use Continuity;
 
-  my $server = new Continuity;
+  my $server = Continuity->new;
   $server->loop;
 
   sub main {

--- a/lib/Continuity/Adapt/FCGI.pm
+++ b/lib/Continuity/Adapt/FCGI.pm
@@ -25,7 +25,7 @@ objects that are sent to applications running inside Continuity.
 
 =over
 
-=item $server = new Continuity::Adapt::FCGI(...)
+=item $server = Continuity::Adapt::FCGI->new(...)
 
 Create a new continuation adapter and HTTP::Daemon. This actually starts the
 HTTP server which is embedded.
@@ -40,9 +40,9 @@ sub new {
   bless $self, $class;
 
   my $env = {};
-  my $in = new IO::Handle;
-  my $out = new IO::Handle;
-  my $err = new IO::Handle;
+  my $in = IO::Handle->new;
+  my $out = IO::Handle->new;
+  my $err = IO::Handle->new;
 
   $self->{fcgi_request} = FCGI::Request($in,$out,$err,$env);
   $self->{in} = $in;


### PR DESCRIPTION
As this syntax is discouraged.

Also, the homepage link appears to be broken or missing:

http://continuity.tlt42.org/
